### PR TITLE
Move from Python slim docker images to normal

### DIFF
--- a/ch1-hello/Dockerfile
+++ b/ch1-hello/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch10-books/Dockerfile
+++ b/ch10-books/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch11-reviews/Dockerfile
+++ b/ch11-reviews/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch12-file-image-uploads/Dockerfile
+++ b/ch12-file-image-uploads/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch13-permissions/Dockerfile
+++ b/ch13-permissions/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch14-orders-with-stripe/Dockerfile
+++ b/ch14-orders-with-stripe/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch15-search/Dockerfile
+++ b/ch15-search/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch16-performance/Dockerfile
+++ b/ch16-performance/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch17-security/Dockerfile
+++ b/ch17-security/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch18-deployment/Dockerfile
+++ b/ch18-deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch2-postgresql/Dockerfile
+++ b/ch2-postgresql/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch3-books/Dockerfile
+++ b/ch3-books/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch4-pages/Dockerfile
+++ b/ch4-pages/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch5-user-registration/Dockerfile
+++ b/ch5-user-registration/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch6-static-assets/Dockerfile
+++ b/ch6-static-assets/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch7-advanced-user-registration/Dockerfile
+++ b/ch7-advanced-user-registration/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch8-environment-variables/Dockerfile
+++ b/ch8-environment-variables/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ch9-email/Dockerfile
+++ b/ch9-email/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.7-slim
+FROM python:3.7
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1


### PR DESCRIPTION
The `slim` image fails to push release logs on Heroku with these errors visible on `heroku logs`:

```
app[release.5093]: /bin/sh: 1: curl: not found
heroku[release.5093]: Process exited with status 0
heroku[release.5093]: State changed from up to complete
app[release.5093]: System check identified no issues (0 silenced).
```

This is because the "slim" image cuts lots of standard tools such as `curl`. Using the standard Python image fixes this.